### PR TITLE
Back to arrow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3714,6 +3714,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,6 +2214,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arrow",
+ "arrow-csv",
  "arrow-schema",
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ csv = "1.3.1"
 zip = "3.0.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chrono = "0.4.41"
 regex = "1.11.1"
 futures = "0.3.31"
 async-trait = "0.1.88"
@@ -54,3 +53,5 @@ polars = { version = "0.48.1", features = [
 ] }
 sysinfo = "0.35.1"
 serde_yaml = "0.9.34"
+arrow-csv = "55.1.0"
+chrono = { version = "0.4.41", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls",
     "cookies",
     "blocking",
+    "stream",
 ] }
 
 reqwest-middleware = "0.4.2" # <- no extra features here

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.8"
 
 services:
   grafana:
@@ -8,7 +7,7 @@ services:
       - "3000:3000"
     user: "1000:1000"               
     volumes:
-      - assets:/data                    # mount the shared assets here
+      - assets:/data                   
       - ./grafana/plugins/motherduck-duckdb-datasource:/var/lib/grafana/plugins/motherduck-duckdb-datasource
       - ./grafana/dashboards:/etc/grafana/provisioned_dashboards
       - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
@@ -23,7 +22,7 @@ services:
     working_dir: /usr/src/app
     user: "1000:1000"               
     volumes:
-      - assets:/usr/src/app/assets      # same “assets” volume, mounted at a different path
+      - assets:/usr/src/app/assets      
     command: ["./target/release/nemscraper"]
 
 volumes:

--- a/grafana/dashboards/all.json
+++ b/grafana/dashboards/all.json
@@ -125,7 +125,7 @@
                     "sort": "none"
                 }
             },
-            "pluginVersion": "12.0.0",
+            "pluginVersion": "12.0.1",
             "targets": [
                 {
                     "datasource": {
@@ -135,7 +135,7 @@
                     "editorMode": "code",
                     "format": 0,
                     "rawQuery": true,
-                    "rawSql": "\r\nSELECT\r\n  time_bucket($__interval, measurement_datetime) AS time,\r\n  CAST(participantid AS VARCHAR) AS metric, -- or TEXT, depending on your SQL dialect\r\n  AVG(measured_mw) AS value\r\nFROM read_parquet('/data/parquet/*FPP_UNIT_MW*.parquet',  union_by_name = true)\r\nWHERE $__timeFilter(measurement_datetime)\r\nGROUP BY 1, 2 -- Group by the aliased columns (time and the new metric)\r\nORDER BY 1, 2 -- Optional, but good for inspection",
+                    "rawSql": "SELECT\r\n  time_bucket($__interval, measurement_datetime) AS time,\r\n  CAST(participantid AS VARCHAR) AS metric,\r\n  AVG(measured_mw) AS value\r\nFROM read_parquet('/data/parquet/FPP---UNIT_MW---1/**/*.parquet', \r\n                  hive_partitioning=true, \r\n                  union_by_name=true)\r\nWHERE $__timeFilter(measurement_datetime)\r\nAND $__timeFilter(date)\r\nGROUP BY 1, 2\r\nORDER BY 1, 2",
                     "refId": "A",
                     "sql": {
                         "columns": [
@@ -238,7 +238,7 @@
                     "sort": "none"
                 }
             },
-            "pluginVersion": "12.0.0",
+            "pluginVersion": "12.0.1",
             "targets": [
                 {
                     "datasource": {
@@ -248,7 +248,7 @@
                     "editorMode": "code",
                     "format": 0,
                     "rawQuery": true,
-                    "rawSql": "SELECT\r\n  time_bucket($__interval, measurement_datetime) AS time,\r\n  SUM(measured_mw) AS value\r\nFROM read_parquet('/data/parquet/*FPP_UNIT_MW*.parquet')\r\nWHERE $__timeFilter(measurement_datetime)\r\nGROUP BY 1\r\nORDER BY 1;\r\n",
+                    "rawSql": "SELECT\r\n  time_bucket($__interval, measurement_datetime) AS time,\r\n  SUM(measured_mw) AS value\r\nFROM read_parquet('/data/parquet/FPP---UNIT_MW---1/**/*.parquet', \r\n                  hive_partitioning=true, \r\n                  union_by_name=true)\r\nWHERE $__timeFilter(measurement_datetime)\r\nAND $__timeFilter(date)\r\nGROUP BY 1\r\nORDER BY 1",
                     "refId": "A",
                     "sql": {
                         "columns": [

--- a/grafana/dashboards/files.json
+++ b/grafana/dashboards/files.json
@@ -18,6 +18,7 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
+    "id": 2,
     "links": [],
     "panels": [
         {
@@ -105,7 +106,7 @@
                     "editorMode": "code",
                     "format": 0,
                     "rawQuery": true,
-                    "rawSql": "SELECT\r\n  time_bucket($__interval, event_time) AS time,\r\n  state                    AS metric,\r\n  count(*)               AS total_count\r\nFROM read_parquet('/data/history/*.parquet', union_by_name = TRUE)\r\nWHERE $__timeFilter(event_time)\r\nGROUP BY 1, 2\r\nORDER BY 1, 2\r\n",
+                    "rawSql": "SELECT\r\n  time_bucket('10s', event_time) AS time,\r\n  state                    AS metric,\r\n  count(*)               AS total_count\r\nFROM read_parquet('/data/history/*.parquet', union_by_name = TRUE)\r\nWHERE $__timeFilter(event_time)\r\nGROUP BY 1, 2\r\nORDER BY 1, 2\r\n",
                     "refId": "A",
                     "sql": {
                         "columns": [
@@ -214,7 +215,7 @@
                     "editorMode": "code",
                     "format": 1,
                     "rawQuery": true,
-                    "rawSql": "SELECT\r\n  time_bucket($__interval, event_time) AS time,\r\n  CAST(SUM(count) AS BIGINT) AS total_count\r\nFROM read_parquet('/data/history/*Proc*.parquet', union_by_name = TRUE)\r\nWHERE $__timeFilter(event_time)\r\nGROUP BY 1\r\nORDER BY 1;\r\n",
+                    "rawSql": "SELECT\r\n  time_bucket('10s', event_time) AS time,\r\n  CAST(SUM(count) AS BIGINT) AS total_count\r\nFROM read_parquet('/data/history/*Proc*.parquet', union_by_name = TRUE)\r\nWHERE $__timeFilter(event_time)\r\nGROUP BY 1\r\nORDER BY 1;\r\n",
                     "refId": "A",
                     "sql": {
                         "columns": [
@@ -253,5 +254,6 @@
     "timepicker": {},
     "timezone": "browser",
     "title": "New dashboard",
-    "version": 0
+    "uid": "a78f110c-caac-4f47-96d3-5772ce7d2120",
+    "version": 1
 }

--- a/src/fetch/zips.rs
+++ b/src/fetch/zips.rs
@@ -1,10 +1,16 @@
 use anyhow::Result;
 use reqwest::Client;
 use std::path::{Path, PathBuf};
-use tokio::fs;
+use std::time::Duration;
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
+use tokio::time::sleep;
+use tokio_stream::StreamExt;
 use url::Url;
 
 /// Download the given ZIP URL and save it under `dest_dir` using the original filename.
+/// Streams directly to disk without loading the entire file into memory.
+/// Retries up to 3 times with exponential backoff on failure.
 /// Returns the full path of the saved file.
 pub async fn download_zip(
     client: &Client,
@@ -13,20 +19,73 @@ pub async fn download_zip(
 ) -> Result<PathBuf> {
     let dest_dir = dest_dir.as_ref();
     let url = Url::parse(url_str)?;
+
     let filename = url
         .path_segments()
         .and_then(|segments| segments.last())
         .filter(|name| !name.is_empty())
         .unwrap_or("download.zip");
+
     let dest_path = dest_dir.join(filename);
 
     if let Some(parent) = dest_path.parent() {
-        fs::create_dir_all(parent).await?;
+        tokio::fs::create_dir_all(parent).await?;
     }
 
-    let resp = client.get(url.as_str()).send().await?.error_for_status()?;
-    let bytes = resp.bytes().await?;
-    fs::write(&dest_path, &bytes).await?;
+    let mut attempt = 0;
+    const MAX_RETRIES: usize = 3;
 
-    Ok(dest_path)
+    loop {
+        attempt += 1;
+
+        match download_attempt(client, &url, &dest_path).await {
+            Ok(()) => {
+                return Ok(dest_path);
+            }
+            Err(e) if attempt >= MAX_RETRIES => {
+                // Clean up any partial file on final failure
+                let _ = tokio::fs::remove_file(&dest_path).await;
+                return Err(e.context(format!(
+                    "Failed to download {} after {} attempts",
+                    url_str, MAX_RETRIES
+                )));
+            }
+            Err(e) => {
+                // Clean up any partial file before retry
+                let _ = tokio::fs::remove_file(&dest_path).await;
+
+                // Exponential backoff: 1s, 2s, 4s
+                let delay = Duration::from_secs(1 << (attempt - 1));
+                tracing::warn!(
+                    "Download attempt {}/{} failed for {}: {}. Retrying in {:?}...",
+                    attempt,
+                    MAX_RETRIES,
+                    url_str,
+                    e,
+                    delay
+                );
+                sleep(delay).await;
+            }
+        }
+    }
+}
+
+/// Single download attempt - downloads the URL and streams to the given path.
+async fn download_attempt(client: &Client, url: &Url, dest_path: &Path) -> Result<()> {
+    let resp = client.get(url.as_str()).send().await?.error_for_status()?;
+
+    // Create the output file
+    let mut file = File::create(dest_path).await?;
+
+    // Stream the response body directly to the file
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk_result) = stream.next().await {
+        let chunk = chunk_result?;
+        file.write_all(&chunk).await?;
+    }
+
+    // Ensure all data is written to disk
+    file.flush().await?;
+
+    Ok(())
 }


### PR DESCRIPTION
Polars was doing unpredictable (at least to me) things with memory, namely loading the entire chunk into memory despite being given a sample row limit when doing the first type inference pass. Using arrow directly seems to be compressing better, although i have not properly benchmarked this (possible i'm missing some other metadata though which is causing the discrepency.)